### PR TITLE
Firmware: add error state support + quality-of-life improvements

### DIFF
--- a/firmware-esphome/iotusbsourcemeasure.yml
+++ b/firmware-esphome/iotusbsourcemeasure.yml
@@ -212,6 +212,7 @@ script:
         if (abs(targetDacSrc - targetDacSink) < 16.0/4096) {  // arbitrary, accounts for INL and some buffer
           ESP_LOGE("update_current", "insufficient separation between current limits DAC values %f, %f",
             targetDacSrc, targetDacSink);
+          id(error)->publish_state("DAC Sep");
           return;
         }
 

--- a/firmware-esphome/iotusbsourcemeasure.yml
+++ b/firmware-esphome/iotusbsourcemeasure.yml
@@ -33,8 +33,11 @@ esphome:
     - delay: 0.1s
     - switch.turn_off: conv_enable
 
-    - delay: 1.0s  # assume enough time for PD to negotiate
+    - delay: 0.5s  # assume enough time for PD to negotiate
     - switch.turn_on: vin_ramp
+    - delay: 0.1s
+    - script.execute: update_current  # set initial DAC values
+    - script.execute: update_voltage
 
   on_loop:
     - script.execute: buckboost_control_loop
@@ -124,7 +127,21 @@ script:
   - id: protection_loop
     then:
     - lambda: |-
-        if (id(temp_fets).state > 80 || id(meas_voltage).get_state() > 31 || id(meas_voltage).get_state() < -1) {
+        if (!id(error).state.empty()) {
+          // don't replace an existing error
+        } else if (!id(conv_en_sense).state) {
+          id(error)->publish_state("SW Fault");  // note, only clearable with device reset
+        } else if (id(temp_buckboost).state > 60) {
+          id(error)->publish_state("SW Overtemp");
+        } else if (id(temp_fets).state > 60) {
+          id(error)->publish_state("FET Overtemp");
+        } else if (id(meas_voltage).get_state() > 32) {
+          id(error)->publish_state("Overvolt");
+        } else if (id(meas_voltage).get_state() < -2) {
+          id(error)->publish_state("Undervolt");
+        }
+        if (!id(error).state.empty()) {
+          id(buckboost_ratio).make_call().set_value(0).perform();
           id(enable).publish_state(false);
           id(range0).turn_off();  // just in case, explicitly turn off the SSRs
           id(range1).turn_off();
@@ -137,12 +154,42 @@ script:
         float rawTargetDacSink, rawTargetDacSrc;
         // calculate the target adc ratios using the measurement calibration factors
         if (id(current_range).current_option() == "3A") {
+          if (id(limit_current_min).state < -3) {  // note partly redundant with control constraints
+            id(limit_current_min).publish_state(-3);
+          } else if (id(limit_current_min).state > -0.1) {  // minimum separation between low and high limits
+            id(limit_current_min).publish_state(-0.1);
+          }
+          if (id(limit_current_max).state > 3) {
+            id(limit_current_max).publish_state(3);
+          } else if (id(limit_current_max).state < 0.1) {
+            id(limit_current_max).publish_state(0.1);
+          }
           rawTargetDacSink = valueToAdc(id(limit_current_min).state, id(kCurrentRatio0), id(kCalCurrent0Factor).state, id(kCalCurrent0Offset).state);
           rawTargetDacSrc = valueToAdc(id(limit_current_max).state, id(kCurrentRatio0), id(kCalCurrent0Factor).state, id(kCalCurrent0Offset).state);
         } else if (id(current_range).current_option() == "300mA") {
+          if (id(limit_current_min).state < -0.3) {
+            id(limit_current_min).publish_state(-0.3);
+          } else if (id(limit_current_min).state > -0.01) {
+            id(limit_current_min).publish_state(-0.01);
+          }
+          if (id(limit_current_max).state > 0.3) {
+            id(limit_current_max).publish_state(0.3);
+          } else if (id(limit_current_max).state < 0.01) {
+            id(limit_current_max).publish_state(0.01);
+          }
           rawTargetDacSink = valueToAdc(id(limit_current_min).state, id(kCurrentRatio1), id(kCalCurrent1Factor).state, id(kCalCurrent1Offset).state);
           rawTargetDacSrc = valueToAdc(id(limit_current_max).state, id(kCurrentRatio1), id(kCalCurrent1Factor).state, id(kCalCurrent1Offset).state);
         } else if (id(current_range).current_option() == "30mA") {
+          if (id(limit_current_min).state < -0.03) {
+            id(limit_current_min).publish_state(-0.03);
+          } else if (id(limit_current_min).state > -0.001) {
+            id(limit_current_min).publish_state(-0.001);
+          }
+          if (id(limit_current_max).state > 0.03) {
+            id(limit_current_max).publish_state(0.03);
+          } else if (id(limit_current_max).state < 0.001) {
+            id(limit_current_max).publish_state(0.001);
+          }
           rawTargetDacSink = valueToAdc(id(limit_current_min).state, id(kCurrentRatio2), id(kCalCurrent2Factor).state, id(kCalCurrent2Offset).state);
           rawTargetDacSrc = valueToAdc(id(limit_current_max).state, id(kCurrentRatio2), id(kCalCurrent2Factor).state, id(kCalCurrent2Offset).state);
         } else {
@@ -160,11 +207,18 @@ script:
 
         // convert to dac ratios, and apply dac calibrations
         targetDacSink = (-targetDacSink + id(kCalSetCurrentOffset).state) * id(kCalSetCurrentFactor).state;
+        targetDacSrc = (-targetDacSrc + id(kCalSetCurrentOffset).state) * id(kCalSetCurrentFactor).state;
+
+        if (abs(targetDacSrc - targetDacSink) < 16.0/4096) {  // arbitrary, accounts for INL and some buffer
+          ESP_LOGE("update_current", "insufficient separation between current limits DAC values %f, %f",
+            targetDacSrc, targetDacSink);
+          return;
+        }
+
         id(dac_isink)->write_state(targetDacSink + 0.5);
         id(dac_ratio_isink)->publish_state(id(dac_isink).rawValue / 4095.0 - 0.5);
         id(dac_value_isink)->publish_state(id(dac_isink).rawValue);
 
-        targetDacSrc = (-targetDacSrc + id(kCalSetCurrentOffset).state) * id(kCalSetCurrentFactor).state;
         id(dac_isrc)->write_state(targetDacSrc + 0.5);
         id(dac_ratio_isrc)->publish_state(id(dac_isrc).rawValue / 4095.0 - 0.5);
         id(dac_value_isrc)->publish_state(id(dac_isrc).rawValue);
@@ -390,6 +444,11 @@ mcp3561:
 mcp4728:
   id: dac_control
 
+text_sensor:
+  - platform: template
+    name: "Error"
+    id: error  # is empty when there is no fault condition
+
 number:
   - platform: template
     name: "${name} Set Voltage"
@@ -411,7 +470,7 @@ number:
     icon: mdi:pan-up
     mode: box
     min_value: -3
-    max_value: -0.01
+    max_value: 0
     step: 0.001
     unit_of_measurement: A
     set_action:
@@ -423,7 +482,7 @@ number:
     id: limit_current_max
     icon: mdi:pan-down
     mode: box
-    min_value: 0.01
+    min_value: 0
     max_value: 3
     step: 0.001
     unit_of_measurement: A

--- a/firmware-esphome/ui.yml
+++ b/firmware-esphome/ui.yml
@@ -105,6 +105,11 @@ light:
               }
             }
 
+            if (!id(error).state.empty()) {
+              it[0] = Color(255, 0, 0, 0);
+              it[2] = Color(255, 0, 0, 0);
+            }
+
             if (id(enable).state) {
               if (id(control_limit_source).state ||
                   (lastCurrentSourcePulses != currentSourcePulses && !lastCurrentLimitState)) {
@@ -230,20 +235,25 @@ display:
       } else {
         lastCurrentLimitState = false;
       }
+
       lastCurrentSourcePulses = currentSourcePulses;
       lastCurrentSinkPulses = currentSinkPulses;
       
       lineY = 20;
-      drawValue(it, valueRightX - 5 - drawValueWidth(id(bdf6x10), 1, 6), lineY, 
-          id(bdf6x10), 1, 4 + currentExtraDigits, id(meas_current).get_state());
-      it.print(valueRightX - 3, lineY + smallOffY, 
-          id(bdf4x6), "A");
+      if (!id(error).state.empty()) {  // error drawn in where current / power goes
+        drawInverted(it, 0, lineY, id(bdf6x10), id(error).state.c_str());
+      } else {
+        drawValue(it, valueRightX - 5 - drawValueWidth(id(bdf6x10), 1, 6), lineY, 
+            id(bdf6x10), 1, 4 + currentExtraDigits, id(meas_current).get_state());
+        it.print(valueRightX - 3, lineY + smallOffY, 
+            id(bdf4x6), "A");
 
-      lineY = 35;
-      drawValue(it, valueRightX - 5 - drawValueWidth(id(bdf6x10), 2, 6), lineY, 
-          id(bdf6x10), 2, 4 + currentExtraDigits, id(deriv_power).get_state());
-      it.print(valueRightX - 3, lineY + smallOffY, 
-          id(bdf4x6), "W");
+        lineY = 35;
+        drawValue(it, valueRightX - 5 - drawValueWidth(id(bdf6x10), 2, 6), lineY, 
+            id(bdf6x10), 2, 4 + currentExtraDigits, id(deriv_power).get_state());
+        it.print(valueRightX - 3, lineY + smallOffY, 
+            id(bdf4x6), "W");
+      }
 
       lineY = 45;
       float scaledJoules;
@@ -350,6 +360,9 @@ binary_sensor:
         - lambda: |-
             if (id(cursor) == 4) {
               id(integrator_reset).press();
+            }
+            if (!id(error).state.empty()) {
+              id(error).publish_state("");
             }
   - platform: gpio
     name: "${name} Dir Up"


### PR DESCRIPTION
Adds an error state (as a text sensor) and propagates it to the UI. An empty error state means no current error, and it can be cleared by the dir-switch center button. Errors are generally protection trips.

Other general quality-of-life improvements:
- set initial DAC values
- auto-clamps current limits to the selected current range, including minimum to ensure minimum DAC value separation
- minimum DAC value separation checked in itself